### PR TITLE
tuned the .gitignore a bit more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+#our own ignores
+build/
+dist/
+
+#from a git repo
 *.pydevproject
 .metadata
 .gradle


### PR DESCRIPTION
put the build/ and dist/  ignores back in.  These are temporary files
that we don’t need to keep track of.